### PR TITLE
use relayState to redirect after login

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -286,7 +286,7 @@ def signin(r, metadata_id):
     r.session['login_next_url'] = next_url
     
     saml_client = _get_saml_client(get_current_domain(r), metadata_id)
-    _, info = saml_client.prepare_for_authenticate(relay_state=redirect_url)
+    _, info = saml_client.prepare_for_authenticate(relay_state=next_url)
 
     redirect_url = None
 

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -173,8 +173,9 @@ def acs(r, metadata_id):
 
     saml_client = _get_saml_client(get_current_domain(r), metadata_id)
     resp = r.POST.get('SAMLResponse', None)
-    print(f"TESTING: session dict: {r.session}")
-    print(f"TESTING: session value: {r.session['login_next_url']}")
+    print(f"TESTING: session id: {id(r.session)}")
+    print(f"TESTING: session keys: {r.session.keys()}")
+    print(f"TESTING: session value: {r.session.get('login_next_url')}")
     next_url = r.session.get('login_next_url', _default_next_url())
 
     if not resp:
@@ -292,6 +293,8 @@ def signin(r, metadata_id):
             redirect_url = value
             break
 
+    print(f"TESTING: session id: {id(r.session)}")
+    print(f"TESTING: session keys: {r.session.keys()}")
     print(f"TESTING: session value: {r.session['login_next_url']}")
     return HttpResponseRedirect(redirect_url)
 

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -173,6 +173,8 @@ def acs(r, metadata_id):
 
     saml_client = _get_saml_client(get_current_domain(r), metadata_id)
     resp = r.POST.get('SAMLResponse', None)
+    print(f"TESTING: session dict: {r.session}")
+    print(f"TESTING: session value: {r.session['login_next_url']}")
     next_url = r.session.get('login_next_url', _default_next_url())
 
     if not resp:
@@ -278,6 +280,7 @@ def signin(r, metadata_id):
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
     r.session['login_next_url'] = next_url
+    
 
     saml_client = _get_saml_client(get_current_domain(r), metadata_id)
     _, info = saml_client.prepare_for_authenticate()
@@ -289,6 +292,7 @@ def signin(r, metadata_id):
             redirect_url = value
             break
 
+    print(f"TESTING: session value: {r.session['login_next_url']}")
     return HttpResponseRedirect(redirect_url)
 
 

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -173,12 +173,10 @@ def acs(r, metadata_id):
 
     saml_client = _get_saml_client(get_current_domain(r), metadata_id)
     resp = r.POST.get('SAMLResponse', None)
-    print(f"TESTING: underlying session key: {r.session.session_key}")
-    print(f"TESTING: session object id: {id(r.session)}")
-    print(f"TESTING: session keys: {r.session.keys()}")
-    print(f"TESTING: session next url value: {r.session.get('login_next_url')}")
-    print(f"TESTING: POST dict: {r.POST}")
+    
     next_url = r.session.get('login_next_url', _default_next_url())
+    # use relay state to redirect due to issue described here
+    # https://github.com/fangli/django-saml2-auth/issues/112#issuecomment-529542145
     next_url = r.POST.get('RelayState', next_url)
 
     if not resp:
@@ -295,11 +293,6 @@ def signin(r, metadata_id):
             redirect_url = value
             break
 
-    print(f"TESTING: redirect_url: {redirect_url}")
-    print(f"TESTING: session object id: {id(r.session)}")
-    print(f"TESTING: underlying session key: {r.session.session_key}")
-    print(f"TESTING: session keys: {r.session.keys()}")
-    print(f"TESTING: session next url value: {r.session['login_next_url']}")
     return HttpResponseRedirect(redirect_url)
 
 

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -176,8 +176,10 @@ def acs(r, metadata_id):
     print(f"TESTING: underlying session key: {r.session.session_key}")
     print(f"TESTING: session object id: {id(r.session)}")
     print(f"TESTING: session keys: {r.session.keys()}")
-    print(f"TESTING: session value: {r.session.get('login_next_url')}")
+    print(f"TESTING: session next url value: {r.session.get('login_next_url')}")
+    print(f"TESTING: POST dict: {r.POST}")
     next_url = r.session.get('login_next_url', _default_next_url())
+    next_url = r.POST.get('RelayState', next_url)
 
     if not resp:
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
@@ -283,9 +285,8 @@ def signin(r, metadata_id):
 
     r.session['login_next_url'] = next_url
     
-
     saml_client = _get_saml_client(get_current_domain(r), metadata_id)
-    _, info = saml_client.prepare_for_authenticate()
+    _, info = saml_client.prepare_for_authenticate(relay_state=redirect_url)
 
     redirect_url = None
 
@@ -294,10 +295,11 @@ def signin(r, metadata_id):
             redirect_url = value
             break
 
+    print(f"TESTING: redirect_url: {redirect_url}")
     print(f"TESTING: session object id: {id(r.session)}")
     print(f"TESTING: underlying session key: {r.session.session_key}")
     print(f"TESTING: session keys: {r.session.keys()}")
-    print(f"TESTING: session value: {r.session['login_next_url']}")
+    print(f"TESTING: session next url value: {r.session['login_next_url']}")
     return HttpResponseRedirect(redirect_url)
 
 

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -173,7 +173,8 @@ def acs(r, metadata_id):
 
     saml_client = _get_saml_client(get_current_domain(r), metadata_id)
     resp = r.POST.get('SAMLResponse', None)
-    print(f"TESTING: session id: {id(r.session)}")
+    print(f"TESTING: underlying session key: {r.session.session_key}")
+    print(f"TESTING: session object id: {id(r.session)}")
     print(f"TESTING: session keys: {r.session.keys()}")
     print(f"TESTING: session value: {r.session.get('login_next_url')}")
     next_url = r.session.get('login_next_url', _default_next_url())
@@ -293,7 +294,8 @@ def signin(r, metadata_id):
             redirect_url = value
             break
 
-    print(f"TESTING: session id: {id(r.session)}")
+    print(f"TESTING: session object id: {id(r.session)}")
+    print(f"TESTING: underlying session key: {r.session.session_key}")
     print(f"TESTING: session keys: {r.session.keys()}")
     print(f"TESTING: session value: {r.session['login_next_url']}")
     return HttpResponseRedirect(redirect_url)


### PR DESCRIPTION
address the problem described in [this thread](https://github.com/fangli/django-saml2-auth/issues/112#issuecomment-529542145)

by using the suggestion given in [this PR](https://github.com/Avature/django-saml2-auth/pull/1)