### PR TITLE
manually format the 'user not found' log msg ourselves

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -239,7 +239,7 @@ def acs(r, metadata_id):
                 import_string(settings.SAML2_AUTH['TRIGGER']['CREATE_USER'])(user_identity)
             is_new_user = True
         else:
-            logger.warning("Denied because no user exists", user_name_id)
+            logger.warning(f"Denied because no user exists, id: {user_name_id}")
             return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
     r.session.flush()


### PR DESCRIPTION
Caused by how we did not use Python's old string formatting operator to inject the problematic id into the log message. This issue caused one of our SAML logging calls to raise its own error last week and consequently the "user not found error" percolated up to a user instead of redirecting them to a denied page. For the sake of clarity, we will now manually format the string injected into the logger (as opposed to allowing the logging module to only generate the final msg if the log would actually be produced) as this is a fairly inexpensive operation.

See logs [here](https://console.cloud.google.com/logs/query;query=SEARCH%2528%22Denied%20because%20no%20user%20exists%22%2529;cursorTimestamp=2023-10-17T07:58:23.274961Z;aroundTime=2023-10-17T07:58:22.381936Z;duration=PT15S?project=passthrough-prod&pli=1&rapt=AEjHL4My3Gn2yRJQgJ7If_bKL_mGXfJp2qyqG6FlkwEInI5DK1RlcACGlVqnSB-c2prc2M4lPio_CbaaIm0nL3h6FnfygjBt_A)

will then update passthrough to use latest SAML proj hash once this PR is merged

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205742900796927